### PR TITLE
MVDPARSER: sv_bigcoords support, fragfile definition update, .json/xml output, some bugfixes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.vs
+Debug
+Release
+*.vcxproj.user

--- a/frag_parser.c
+++ b/frag_parser.c
@@ -681,8 +681,12 @@ void Frags_Parse(mvd_info_t *mvd, char *fragmessage, int level)
 		case mt_suicide :
 		{
 			mvd->fragstats[p1->pnum].suicides++;
-			p1->death_count++;
-			Log_Event(&logger, mvd, LOG_DEATH, p1->pnum);			
+
+			// If it's a normal suicide then it'll get picked up by health < 0
+			if (!mess->wclass_index) {
+				p1->death_count++;
+				Log_Event(&logger, mvd, LOG_DEATH, p1->pnum);
+			}
 			break;
 		}
 		case mt_fragged :

--- a/frag_parser.c
+++ b/frag_parser.c
@@ -203,6 +203,12 @@ static void InitFragDefs(void)
 		goto nextline;																			\
 	}
 
+#define FRAGS_CHECKARGS3(x, y, z)																		\
+	if (c != x && c != y && c != z) {																	\
+		Sys_PrintError("Fragfile warning (line %d): %d, %d or %d tokens expected\n", line, x, y, z);	\
+		goto nextline;																					\
+	}
+
 #define	FRAGS_CHECK_VERSION_DEFINED()																	\
 	if (!gotversion) {																					\
 		Sys_PrintError("Fragfile error: #FRAGFILE VERSION must be defined at the head of the file\n");	\
@@ -345,7 +351,7 @@ qbool LoadFragFile(char *filename, qbool quiet)
 
 			if (!strcasecmp(Cmd_Argv(1), "WEAPON_CLASS") || !strcasecmp(Cmd_Argv(1), "WC")) 
 			{
-				FRAGS_CHECKARGS2(4, 5);
+				FRAGS_CHECKARGS3(4, 5, 6);
 				token = Cmd_Argv(2);
 			
 				if (!strcasecmp(token, "NOWEAPON") || !strcasecmp(token, "NONE") || !strcasecmp(token, "NULL")) 

--- a/logger.c
+++ b/logger.c
@@ -1197,6 +1197,12 @@ static char *LogVar_teamplay(mvd_info_t *mvd, const char *varname, int player_nu
 
 static char *LogVar_map(mvd_info_t *mvd, const char *varname, int player_num)
 {
+	// to keep old templates correct: used to return mapname from svc_serverdata and then overwrite with file from serverinfo
+	return mvd->serverinfo.mapfile;
+}
+
+static char* LogVar_mapname(mvd_info_t* mvd, const char* varname, int player_num)
+{
 	return mvd->serverinfo.mapname;
 }
 
@@ -1289,6 +1295,7 @@ logvar_t logvar_list[] =
 	LOGVAR_DEFINE(matchtime, LOGVAR_DEMO),
 	LOGVAR_DEFINE(mvdframe, LOGVAR_DEMO),
 	LOGVAR_DEFINE(map, LOGVAR_DEMO),
+	LOGVAR_DEFINE(mapname, LOGVAR_DEMO),
 	LOGVAR_DEFINE(gamedir, LOGVAR_DEMO),
 	LOGVAR_DEFINE(maxfps, LOGVAR_DEMO),
 	LOGVAR_DEFINE(zext, LOGVAR_DEMO),

--- a/logger.c
+++ b/logger.c
@@ -709,6 +709,16 @@ void Log_OutputFilesHashTable_Clear(logger_t *logger)
 //								Log variables
 // ============================================================================
 
+static char* LogVar_suicides(mvd_info_t* mvd, const char* varname, int player_num)
+{
+	return va("%d", mvd->fragstats[player_num].suicides);
+}
+
+static char* LogVar_teamkills(mvd_info_t* mvd, const char* varname, int player_num)
+{
+	return va("%d", mvd->fragstats[player_num].teamkills);
+}
+
 static char *LogVar_name(mvd_info_t *mvd, const char *varname, int player_num)
 {
 	return mvd->players[player_num].name;
@@ -1360,7 +1370,9 @@ logvar_t logvar_list[] =
 	LOGVAR_DEFINE(topcolor, LOGVAR_PLAYER),
 	LOGVAR_DEFINE(bottomcolor, LOGVAR_PLAYER),
 	LOGVAR_DEFINE(droppedweapon, LOGVAR_PLAYER),
-	LOGVAR_DEFINE(droppedweaponstr, LOGVAR_PLAYER)
+	LOGVAR_DEFINE(droppedweaponstr, LOGVAR_PLAYER),
+	LOGVAR_DEFINE(teamkills, LOGVAR_PLAYER),
+	LOGVAR_DEFINE(suicides, LOGVAR_PLAYER)
 };
 
 #define LOGVARS_LIST_SIZE		(sizeof(logvar_list) / sizeof(logvar_t))

--- a/logger.c
+++ b/logger.c
@@ -102,6 +102,14 @@ static log_eventlogger_type_t Log_ParseEventloggerType(const char *event_logger_
 	{
 		return LOG_MATCHEND_ALL;
 	}
+	else if (!strcasecmp(event_logger_type, "MATCHEND_ALL_BETWEEN"))
+	{
+		return LOG_MATCHEND_ALL_BETWEEN;
+	}
+	else if (!strcasecmp(event_logger_type, "MATCHEND_FINAL"))
+	{
+		return LOG_MATCHEND_FINAL;
+	}
 	else if (!strcasecmp(event_logger_type, "DEMOSTART"))
 	{
 		return LOG_DEMOSTART;

--- a/logger.c
+++ b/logger.c
@@ -482,6 +482,10 @@ char *Log_ExpandTemplateString(logger_t *logger, mvd_info_t *mvd, const char *te
 				}
 
 				input = var_end;
+
+				if (!input[0]) {
+					break;
+				}
 			}
 		}
 
@@ -554,7 +558,6 @@ void Log_Event(logger_t *logger, mvd_info_t *mvd, log_eventlogger_type_t type, i
 	int i;
 	int j;
 	int p;
-	int e;
 	int player_start				= player_num;
 	int player_count				= 1;
 	int output_len[encoding_count]	= { 0, 0, 0 };

--- a/logger.h
+++ b/logger.h
@@ -29,7 +29,9 @@ typedef enum log_eventlogger_type_s
 	LOG_DEMOEND,
 	LOG_SPAWN,
 	LOG_ITEMPICKUP,
-	LOG_WEAPONDROP
+	LOG_WEAPONDROP,
+	LOG_MATCHEND_FINAL,
+	LOG_MATCHEND_ALL_BETWEEN
 } log_eventlogger_type_t;
 
 typedef struct log_outputfile_template_s

--- a/logger.h
+++ b/logger.h
@@ -7,11 +7,20 @@
 #define LOG_OUTPUTFILES_HASHTABLE_SIZE	512
 #define LOG_MAX_ID_LENGTH				32
 
+typedef enum encoding_mode_s {
+	normal_encoding,
+	json_encoding,
+	xml_encoding,
+
+	encoding_count
+} encoding_mode_t;
+
 typedef struct log_outputfile_s
 {
 	char					*filename;		// Expanded filename.
 	FILE					*file;			// The file pointer to the opened file.
 	unsigned long			filename_hash;	// A hash of the expanded filename.
+	encoding_mode_t         encoding;       // format to encode strings
 	struct log_outputfile_s	*next;			// Pointer to the next outputfile (if there's a collision in the hash table).
 } log_outputfile_t; 
 

--- a/mvd_parser.c
+++ b/mvd_parser.c
@@ -485,6 +485,7 @@ qbool MVD_Parser_StartParse(char *demopath, byte *mvdbuf, long filelen)
 	if (!mvd.serverinfo.match_ended)
 	{
 		int i;
+		qbool any = false;
 
 		Log_Event(&logger, &mvd, LOG_MATCHEND, -1);
 
@@ -496,8 +497,13 @@ qbool MVD_Parser_StartParse(char *demopath, byte *mvdbuf, long filelen)
 				continue;
 			}
 
+			if (any)
+				Log_Event(&logger, &mvd, LOG_MATCHEND_ALL_BETWEEN, i);
 			Log_Event(&logger, &mvd, LOG_MATCHEND_ALL, i);
+			any = true;
 		}
+
+		Log_Event(&logger, &mvd, LOG_MATCHEND_FINAL, -1);
 	}
 
 	Log_Event(&logger, &mvd, LOG_DEMOEND, -1);

--- a/mvdparser.sln
+++ b/mvdparser.sln
@@ -1,7 +1,9 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 9.00
-# Visual Studio 2005
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mvdparser", "mvdparser.vcproj", "{116496EC-DD8D-4C48-8965-0D4961C76504}"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30309.148
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mvdparser", "mvdparser.vcxproj", "{116496EC-DD8D-4C48-8965-0D4961C76504}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -16,5 +18,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B18BE4CC-108E-4DB5-9241-BC6FBCBA96EC}
 	EndGlobalSection
 EndGlobal

--- a/mvdparser.vcxproj
+++ b/mvdparser.vcxproj
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{116496EC-DD8D-4C48-8965-0D4961C76504}</ProjectGuid>
+    <RootNamespace>mvdparser</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>16.0.30028.132</_ProjectFileVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_CRT_SECURE_NO_WARNINGS;_CRT_NONSTDC_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>CompileAsC</CompileAs>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <StackReserveSize>500000000</StackReserveSize>
+      <StackCommitSize>500000000</StackCommitSize>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>WIN32;_CONSOLE;_CRT_NONSTDC_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeader />
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <ShowProgress>NotSet</ShowProgress>
+      <OutputFile>$(OutDir)$(ProjectName).exe</OutputFile>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <StackReserveSize>500000000</StackReserveSize>
+      <StackCommitSize>500000000</StackCommitSize>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="frag_parser.c" />
+    <ClCompile Include="logger.c" />
+    <ClCompile Include="main.c" />
+    <ClCompile Include="mvd_parser.c" />
+    <ClCompile Include="netmsg_parser.c" />
+    <ClCompile Include="net_msg.c" />
+    <ClCompile Include="qw_protocol.c" />
+    <ClCompile Include="shared.c" />
+    <ClCompile Include="strptime.c" />
+    <ClCompile Include="sys_win.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="endian.h" />
+    <ClInclude Include="frag_parser.h" />
+    <ClInclude Include="logger.h" />
+    <ClInclude Include="maindef.h" />
+    <ClInclude Include="mvd_parser.h" />
+    <ClInclude Include="netmsg_parser.h" />
+    <ClInclude Include="net_msg.h" />
+    <ClInclude Include="qw_protocol.h" />
+    <ClInclude Include="stats.h" />
+    <ClInclude Include="strptime.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/mvdparser.vcxproj.filters
+++ b/mvdparser.vcxproj.filters
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="frag_parser.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="logger.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="main.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="mvd_parser.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="net_msg.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="netmsg_parser.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="qw_protocol.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="shared.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="strptime.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="sys_win.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="endian.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="frag_parser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="logger.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="maindef.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="mvd_parser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="net_msg.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="netmsg_parser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="qw_protocol.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="stats.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="strptime.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/net_msg.c
+++ b/net_msg.c
@@ -4,6 +4,8 @@
 #include "qw_protocol.h"
 #include "net_msg.h"
 
+static qbool use_bigcoords = false;
+
 sizebuf_t net_message;
 int msg_readcount;
 qbool msg_badread;
@@ -162,11 +164,17 @@ char *MSG_ReadStringLine(void)
 
 float MSG_ReadCoord (void)
 {
+	if (use_bigcoords) {
+		return MSG_ReadFloat();
+	}
 	return MSG_ReadShort() * (1.0f / 8);
 }
 
 float MSG_ReadAngle (void)
 {
+	if (use_bigcoords) {
+		return MSG_ReadAngle16();
+	}
 	return MSG_ReadChar() * (360.0f / 256);
 }
 
@@ -236,4 +244,9 @@ void MSG_ReadDeltaUsercmd(usercmd_t *from, usercmd_t *move, int protoversion)
 	{
 		move->msec = MSG_ReadByte (); // always sent
 	}
+}
+
+void MSG_SetBigCoordSupport(qbool enabled)
+{
+	use_bigcoords = enabled;
 }

--- a/net_msg.h
+++ b/net_msg.h
@@ -26,5 +26,6 @@ float MSG_ReadAngle16 (void);
 #define CM_MSEC	(1 << 7) // same as CM_ANGLE2
 
 void MSG_ReadDeltaUsercmd(usercmd_t *from, usercmd_t *move, int protoversion);
+void MSG_SetBigCoordSupport(qbool enabled);
 
 #endif // __NET_MSG_H__

--- a/netmsg_parser.c
+++ b/netmsg_parser.c
@@ -818,7 +818,26 @@ static void NetMsg_Parser_Parse_svc_setangle(void)
 
 static void NetMsg_Parser_Parse_svc_serverdata(mvd_info_t *mvd)
 {
-	mvd->serverinfo.protocol_version	= MSG_ReadLong();
+	int protocol;
+
+	while (true) {
+		protocol = MSG_ReadLong();
+		if (protocol == PROTOCOL_VERSION_FTE) {
+			mvd->extension_flags_fte1 = MSG_ReadLong();
+			MSG_SetBigCoordSupport(mvd->extension_flags_fte1 & FTE_PEXT_FLOATCOORDS);
+		}
+		else if (protocol == PROTOCOL_VERSION_FTE2) {
+			mvd->extension_flags_fte2 = MSG_ReadLong();
+		}
+		else if (protocol == PROTOCOL_VERSION_MVD1) {
+			mvd->extension_flags_mvd = MSG_ReadLong();
+		}
+		else {
+			break;
+		}
+	}
+
+	mvd->serverinfo.protocol_version	= protocol;
 	mvd->serverinfo.servercount			= MSG_ReadLong();
 
 	// Gamedir.

--- a/netmsg_parser.c
+++ b/netmsg_parser.c
@@ -791,7 +791,7 @@ static void NetMsg_Parser_ParseServerInfo(mvd_info_t *mvd)
 		snprintf(mvd->serverinfo.mod, sizeof(mvd->serverinfo.mod), "KTX %s build %s", tmp, Info_ValueForKey(mvd->serverinfo.serverinfo, "xbuild"));
 	}
 
-	strlcpy(mvd->serverinfo.mapname, Info_ValueForKey(mvd->serverinfo.serverinfo, "map"), sizeof(mvd->serverinfo.mapname));
+	strlcpy(mvd->serverinfo.mapfile, Info_ValueForKey(mvd->serverinfo.serverinfo, "map"), sizeof(mvd->serverinfo.mapfile));
 	strlcpy(mvd->serverinfo.serverversion, Info_ValueForKey(mvd->serverinfo.serverinfo, "*version"), sizeof(mvd->serverinfo.serverversion));
 	strlcpy(mvd->serverinfo.status, Info_ValueForKey(mvd->serverinfo.serverinfo, "status"), sizeof(mvd->serverinfo.status));
 }

--- a/netmsg_parser.c
+++ b/netmsg_parser.c
@@ -659,6 +659,9 @@ static void NetMsg_Parser_Parse_svc_print(mvd_info_t *mvd)
 	strlcpy(str, MSG_ReadString(), sizeof(str)); 
 
 	// TODO : Check for frag messages spread over several svc_prints older mods/servers does this crap :(
+	if (str[strlen(str) - 1] == '\n') {
+		str[strlen(str) - 1] = '\0';
+	}
 
 	Sys_PrintDebug(5, "svc_print: (%s) RAW: %s\n", print_strings[level], str);
 	Sys_PrintDebug(1, "svc_print: (%s) %s\n", print_strings[level], Sys_RedToWhite(str));

--- a/netmsg_parser.c
+++ b/netmsg_parser.c
@@ -711,6 +711,7 @@ static void NetMsg_Parser_Parse_svc_print(mvd_info_t *mvd)
 		else if (!strncmp(str, "The match is over", 17))
 		{
 			int i;
+			qbool any = false;
 
 			mvd->serverinfo.match_ended = true;
 			Log_Event(&logger, mvd, LOG_MATCHEND, -1);
@@ -723,8 +724,13 @@ static void NetMsg_Parser_Parse_svc_print(mvd_info_t *mvd)
 					continue;
 				}
 
+				if (any)
+					Log_Event(&logger, mvd, LOG_MATCHEND_ALL_BETWEEN, i);
 				Log_Event(&logger, mvd, LOG_MATCHEND_ALL, i);
+				any = true;
 			}
+
+			Log_Event(&logger, mvd, LOG_MATCHEND_FINAL, -1);
 		}
 		else if (strstr(str, "overtime follows"))
 		{

--- a/qw_protocol.h
+++ b/qw_protocol.h
@@ -546,6 +546,10 @@ typedef struct mvd_info_s
 
 	log_event_t		*log_events_tail;
 	log_event_t		*log_events_head;
+
+	unsigned int    extension_flags_fte1;
+	unsigned int    extension_flags_fte2;
+	unsigned int    extension_flags_mvd;
 } mvd_info_t;
 
 // usercmd button bits
@@ -583,5 +587,12 @@ typedef struct temp_entity_list_s
 } temp_entity_list_t;
 
 temp_entity_list_t	temp_entities;
+
+// Protocol extensions
+#define PROTOCOL_VERSION_FTE    (('F'<<0) + ('T'<<8) + ('E'<<16) + ('X' << 24)) //fte extensions.
+#define PROTOCOL_VERSION_FTE2   (('F'<<0) + ('T'<<8) + ('E'<<16) + ('2' << 24))	//fte extensions.
+#define PROTOCOL_VERSION_MVD1   (('M'<<0) + ('V'<<8) + ('D'<<16) + ('1' << 24)) //mvdsv extensions.
+
+#define FTE_PEXT_FLOATCOORDS  0x00008000
 
 #endif // __QW_PROTOCOL_H__

--- a/qw_protocol.h
+++ b/qw_protocol.h
@@ -462,34 +462,35 @@ typedef struct movevars_s
 
 typedef struct server_s
 {
-	char		serverinfo[2 * MAX_SERVERINFO_STRING]; // Make it larger than allowed.
-	int			protocol_version;
-	int			servercount;
-	float		demotime;
-	int			timelimit;
-	int			fraglimit;
-	int			teamplay;
-	int			deathmatch;
-	qbool		watervis;
-	char		serverversion[MAX_INFO_KEY];
-	int			maxclients;
-	int			maxspectators;
-	char		mapname[MAX_INFO_KEY];
-	int			fpd;
-	char		status[MAX_INFO_KEY];
-	char		gamedir[MAX_QPATH];
-	movevars_t	movevars;
-	qbool		countdown;
-	qbool		match_started;
-	qbool		match_ended;
-	qbool		match_overtime;
-	int			overtime_minutes;
-	int			maxfps;
-	int			zext;
-	char		hostname[MAX_INFO_STRING];
-	char		mod[MAX_INFO_STRING];
-	qbool		player_timed_out;
-	int			player_timout_frame;
+	char        serverinfo[2 * MAX_SERVERINFO_STRING]; // Make it larger than allowed.
+	int         protocol_version;
+	int         servercount;
+	float       demotime;
+	int         timelimit;
+	int         fraglimit;
+	int         teamplay;
+	int         deathmatch;
+	qbool       watervis;
+	char        serverversion[MAX_INFO_KEY];
+	int         maxclients;
+	int         maxspectators;
+	char        mapname[MAX_INFO_KEY];                 // now the friendly name (Blood Run)
+	char        mapfile[MAX_INFO_KEY];                 // now the name of the file (ztndm3)
+	int         fpd;
+	char        status[MAX_INFO_KEY];
+	char        gamedir[MAX_QPATH];
+	movevars_t  movevars;
+	qbool       countdown;
+	qbool       match_started;
+	qbool       match_ended;
+	qbool       match_overtime;
+	int         overtime_minutes;
+	int         maxfps;
+	int         zext;
+	char        hostname[MAX_INFO_STRING];
+	char        mod[MAX_INFO_STRING];
+	qbool       player_timed_out;
+	int         player_timout_frame;
 } server_t;
 
 typedef enum log_eventtype_s

--- a/shared.c
+++ b/shared.c
@@ -186,7 +186,8 @@ size_t strlcat(char *dst, const char *src, size_t siz)
 	return(dlen + (s - src));       /* count does not include NUL */
 }
 
-#ifdef _MSC_VER
+// Implemented in later versions of Visual Studio (https://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010)
+#if defined(_MSC_VER) && _MSC_VER < 1900
 int snprintf(char *buffer, size_t count, char const *format, ...)
 {
 	int ret;

--- a/shared.c
+++ b/shared.c
@@ -289,7 +289,8 @@ qbool COM_ReadFile(const char *filename, byte **data, long *filelen)
 			return false;
 		}
 
-		(*data) = Q_malloc(sizeof(byte) * len);
+		(*data) = Q_malloc(sizeof(byte) * (len + 1));
+		(*data)[len] = '\0';
 
 		num_read = fread((*data), 1, len, f);
 

--- a/template.dat
+++ b/template.dat
@@ -128,3 +128,89 @@ demotime=%demotime%;matchtime=%matchtime%;quake_loc_x=%posx%;quake_loc_y=%posy%;
 
 ////////////////////////////////////////////////////////////
 
+#FILE json %demoname%.json
+
+#EVENT MATCHEND	6
+{
+    "hostname": "%hostname%",
+    "map_name": "%map%",
+    "map_file": "??",
+    "gamedir": "%gamedir%",
+    "serverinfo": "%serverinfo%",
+    "fraglimit": "%fraglimit%",
+    "timelimit": "%timelimit%",
+    "deathmatch": "%deathmatchmode%",
+    "maxfps": "%maxfps%",
+    "teamplay": "%teamplay%",
+    "z_ext": "%zext%",
+    "fpd": "%fpd%",
+    "maxclients": "%maxclients%",
+    "maxspectators": "%maxspectators%",
+    "watervis": "%watervis%",
+    "gametype": "unknown",
+    "version": "%serverversion%",
+    "mod": "%mod%",
+    "players": [
+#EVENT_END
+
+#EVENT MATCHEND_ALL 7
+            {
+                "client": "%client%",
+                "name_sanatized": "%name%",
+                "name_raw": "%nameraw%",
+                "player_num": "%playernum%",
+                "player_id": "%playerid%",
+                "frags": "%frags%",
+                "spectator": "%spectator%",
+                "userinfo": "%userinfo%",
+                "top_color": "%topcolor%",
+                "bottom_color": "%bottomcolor%",
+                "team_sanatized": "%team%",
+                "team_raw": "%teamraw%",
+                "avg_packetloss": "%avgpl%",
+                "max_packetloss": "%maxpl%",
+                "min_packetloss": "%minpl%",
+                "avg_ping": "%avgping%",
+                "max_ping": "%maxping%",
+                "min_ping": "%minping%",
+                "sg_shots": "%sgshots%",
+                "avg_speed": "%avgspeed%",
+                "max_speed": "%maxspeed%",
+                "distance_moved": "%distancemoved%",
+                "stats": {
+                    "Axe":{"Damage":0,"Drop":0,"Pickup":0},
+                    "Deaths": "%deaths%",
+                    "GreenArmor":{"Damage_Absorbed":0,"Pickup":%gacount%},
+                    "GrenadeLauncher":{"Damage":0,"Drop":%gldrop%,"Pickup":%glcount%,"Shots":%glshots%},
+                    "Kills":27,
+                    "LightningGun":{"Damage":0,"Drop":%lgdrop%,"Pickup":%lgcount%,"Shots":%lgshots%},
+                    "MegaHealth":{"Drop":0,"Pickup":%mhcount%},
+                    "NailGun":{"Damage":0,"Drop":%ngdrop%,"Pickup":%ngcount%,"Shots":%ngshots%},
+                    "Pentagram":{"Drop":0,"Pickup":%pentcount%},
+                    "Quad":{"Drop":0,"Pickup":%quadcount%},
+                    "RedArmor":{"Damage_Absorbed":0,"Pickup":%racount%},
+                    "Ring":{"Drop":0,"Pickup":%ringcount%},
+                    "RocketLauncher":{"Damage":0,"Drop":%rldrop%,"Pickup":%rlcount%,"Shots":%rlshots%},
+                    "Shotgun":{"Damage":0,"Drop":0,"Pickup":0},
+                    "Suicides":%suicides%,
+                    "SuperNailGun":{"Damage":0,"Drop":%sngdrop%,"Pickup":%sngcount%,"Shots":%sngshots%},
+                    "SuperShotgun":{"Damage":0,"Drop":%ssgdrop%,"Pickup":%ssgcount%,"Shots":%ssgshots%},
+                    "Teamkills":%teamkills%,
+                    "YellowArmor":{"Damage_Absorbed":0,"Pickup":%yacount%}
+                }
+            }
+#EVENT_END
+
+#EVENT MATCHEND_ALL_BETWEEN 8
+    ,
+#EVENT_END
+
+#EVENT MATCHEND_FINAL 9
+    ]
+}
+#EVENT_END
+
+#OUTPUT 6 json
+#OUTPUT 7 json
+#OUTPUT 8 json
+#OUTPUT 9 json

--- a/template.dat
+++ b/template.dat
@@ -133,8 +133,8 @@ demotime=%demotime%;matchtime=%matchtime%;quake_loc_x=%posx%;quake_loc_y=%posy%;
 #EVENT MATCHEND	6
 {
     "hostname": "%hostname%",
-    "map_name": "%map%",
-    "map_file": "??",
+    "map_name": "%mapname%",
+    "map_file": "maps/%map%.bsp",
     "gamedir": "%gamedir%",
     "serverinfo": "%serverinfo%",
     "fraglimit": "%fraglimit%",


### PR DESCRIPTION
Adds support for mvd files saved with FTE's sv_bigcoords enabled
Can load fragfile.dat files with tracker images in weapon definitions (added in 2009)
Extra events for defining output between players and at end of match
Encode strings for XML/json format (format taken from file extension)
Default template definition updated to create `demoname.json`, format is for T2H 2v2 tournament
When a player bored, their death counted twice (now only counts from fragfile.dat if weapon class is unknown)
Input files not null-terminated (problem for fragfile.dat reading)
Buffer over-run when token at end of event text is replaced